### PR TITLE
Proper detection of OpenGL ES 3.2 on Android

### DIFF
--- a/src/glfm_platform_android.c
+++ b/src/glfm_platform_android.c
@@ -490,7 +490,9 @@ static bool _glfmEGLContextInit(GLFMPlatformData *platformData) {
                 eglQueryContext(platformData->eglDisplay, platformData->eglContext,
                                 EGL_CONTEXT_MINOR_VERSION_KHR, &minorVersion);
             }
-            if (majorVersion == 3 && minorVersion == 1) {
+            if (majorVersion == 3 && minorVersion == 2) {
+                platformData->renderingAPI = GLFMRenderingAPIOpenGLES32;
+            } else if (majorVersion == 3 && minorVersion == 1) {
                 platformData->renderingAPI = GLFMRenderingAPIOpenGLES31;
             } else if (majorVersion == 3) {
                 platformData->renderingAPI = GLFMRenderingAPIOpenGLES3;


### PR DESCRIPTION
Fixed missing if clause for detecting OpenGL ES 3.2. With this change, glfmGetRenderingAPI properly returns OpenGL ES 3.2 when detected. Without it it returns OpenGL ES 3, which is only partially true and thus a bit confusing.