### PR TITLE
Return previously set input callbacks when setting new

### DIFF
--- a/include/glfm.h
+++ b/include/glfm.h
@@ -312,37 +312,40 @@ bool glfmExtensionSupported(const char *extension);
 GLFMProc glfmGetProcAddress(const char *functionName);
 
 /// Sets the function to call before each frame is displayed.
-void glfmSetMainLoopFunc(GLFMDisplay *display, GLFMMainLoopFunc mainLoopFunc);
+GLFMMainLoopFunc glfmSetMainLoopFunc(GLFMDisplay *display, GLFMMainLoopFunc mainLoopFunc);
 
 /// Sets the function to call when a mouse or touch event occurs.
-void glfmSetTouchFunc(GLFMDisplay *display, GLFMTouchFunc touchFunc);
+GLFMTouchFunc glfmSetTouchFunc(GLFMDisplay *display, GLFMTouchFunc touchFunc);
 
 /// Sets the function to call when a key event occurs.
 /// Note, on iOS, only pressed events are sent (no repeated or released events) and with no
 /// modifiers.
-void glfmSetKeyFunc(GLFMDisplay *display, GLFMKeyFunc keyFunc);
+GLFMKeyFunc glfmSetKeyFunc(GLFMDisplay *display, GLFMKeyFunc keyFunc);
 
 /// Sets the function to call when character input events occur.
-void glfmSetCharFunc(GLFMDisplay *display, GLFMCharFunc charFunc);
+GLFMCharFunc glfmSetCharFunc(GLFMDisplay *display, GLFMCharFunc charFunc);
 
 /// Sets the function to call when the surface could not be created.
 /// For example, the browser does not support WebGL.
-void glfmSetSurfaceErrorFunc(GLFMDisplay *display, GLFMSurfaceErrorFunc surfaceErrorFunc);
+GLFMSurfaceErrorFunc glfmSetSurfaceErrorFunc(GLFMDisplay *display,
+                                             GLFMSurfaceErrorFunc surfaceErrorFunc);
 
 /// Sets the function to call when the surface was created.
-void glfmSetSurfaceCreatedFunc(GLFMDisplay *display, GLFMSurfaceCreatedFunc surfaceCreatedFunc);
+GLFMSurfaceCreatedFunc glfmSetSurfaceCreatedFunc(GLFMDisplay *display,
+                                                 GLFMSurfaceCreatedFunc surfaceCreatedFunc);
 
 /// Sets the function to call when the surface was resized (or rotated).
-void glfmSetSurfaceResizedFunc(GLFMDisplay *display, GLFMSurfaceResizedFunc surfaceResizedFunc);
+GLFMSurfaceResizedFunc glfmSetSurfaceResizedFunc(GLFMDisplay *display,
+                                                 GLFMSurfaceResizedFunc surfaceResizedFunc);
 
 /// Sets the function to call when the surface was destroyed. For example, OpenGL context loss.
 /// All OpenGL resources should be deleted in this call.
-void glfmSetSurfaceDestroyedFunc(GLFMDisplay *display,
-                                 GLFMSurfaceDestroyedFunc surfaceDestroyedFunc);
+GLFMSurfaceDestroyedFunc glfmSetSurfaceDestroyedFunc(GLFMDisplay *display,
+                                                     GLFMSurfaceDestroyedFunc surfaceDestroyedFunc);
 
-void glfmSetMemoryWarningFunc(GLFMDisplay *display, GLFMMemoryWarningFunc lowMemoryFunc);
+GLFMMemoryWarningFunc glfmSetMemoryWarningFunc(GLFMDisplay *display, GLFMMemoryWarningFunc lowMemoryFunc);
 
-void glfmSetAppFocusFunc(GLFMDisplay *display, GLFMAppFocusFunc focusFunc);
+GLFMAppFocusFunc glfmSetAppFocusFunc(GLFMDisplay *display, GLFMAppFocusFunc focusFunc);
 
 /// Requests to show or hide the onscreen virtual keyboard. On Emscripten, this function does
 /// nothing.
@@ -352,8 +355,9 @@ void glfmSetKeyboardVisible(GLFMDisplay *display, bool visible);
 bool glfmIsKeyboardVisible(GLFMDisplay *display);
 
 /// Sets the function to call when the virtual keyboard changes visibility or changes bounds.
-void glfmSetKeyboardVisibilityChangedFunc(GLFMDisplay *display,
-                                          GLFMKeyboardVisibilityChangedFunc visibilityChangedFunc);
+GLFMKeyboardVisibilityChangedFunc
+glfmSetKeyboardVisibilityChangedFunc(GLFMDisplay *display,
+                                     GLFMKeyboardVisibilityChangedFunc visibilityChangedFunc);
 
 // MARK: Platform-specific functions
 

--- a/src/glfm_platform.h
+++ b/src/glfm_platform.h
@@ -61,10 +61,14 @@ struct GLFMDisplay {
 
 // MARK: Setters
 
-void glfmSetSurfaceErrorFunc(GLFMDisplay *display, GLFMSurfaceErrorFunc surfaceErrorFunc) {
+GLFMSurfaceErrorFunc glfmSetSurfaceErrorFunc(GLFMDisplay *display,
+                                             GLFMSurfaceErrorFunc surfaceErrorFunc) {
+    GLFMSurfaceErrorFunc previous = NULL;
     if (display) {
+        previous = display->surfaceErrorFunc;
         display->surfaceErrorFunc = surfaceErrorFunc;
     }
+    return previous;
 }
 
 void glfmSetDisplayConfig(GLFMDisplay *display,
@@ -109,66 +113,98 @@ void glfmSetDisplayChrome(GLFMDisplay *display, GLFMUserInterfaceChrome uiChrome
     }
 }
 
-void glfmSetMainLoopFunc(GLFMDisplay *display, GLFMMainLoopFunc mainLoopFunc) {
+GLFMMainLoopFunc glfmSetMainLoopFunc(GLFMDisplay *display, GLFMMainLoopFunc mainLoopFunc) {
+    GLFMMainLoopFunc previous = NULL;
     if (display) {
+        previous = display->mainLoopFunc;
         display->mainLoopFunc = mainLoopFunc;
     }
+    return previous;
 }
 
-void glfmSetSurfaceCreatedFunc(GLFMDisplay *display, GLFMSurfaceCreatedFunc surfaceCreatedFunc) {
+GLFMSurfaceCreatedFunc glfmSetSurfaceCreatedFunc(GLFMDisplay *display,
+                                                 GLFMSurfaceCreatedFunc surfaceCreatedFunc) {
+    GLFMSurfaceCreatedFunc previous = NULL;
     if (display) {
+        previous = display->surfaceCreatedFunc;
         display->surfaceCreatedFunc = surfaceCreatedFunc;
     }
+    return previous;
 }
 
-void glfmSetSurfaceResizedFunc(GLFMDisplay *display, GLFMSurfaceResizedFunc surfaceResizedFunc) {
+GLFMSurfaceResizedFunc glfmSetSurfaceResizedFunc(GLFMDisplay *display,
+                                                 GLFMSurfaceResizedFunc surfaceResizedFunc) {
+    GLFMSurfaceResizedFunc previous = NULL;
     if (display) {
+        previous = display->surfaceResizedFunc;
         display->surfaceResizedFunc = surfaceResizedFunc;
     }
+    return previous;
 }
 
-void glfmSetSurfaceDestroyedFunc(GLFMDisplay *display,
-                                 GLFMSurfaceDestroyedFunc surfaceDestroyedFunc) {
+GLFMSurfaceDestroyedFunc glfmSetSurfaceDestroyedFunc(GLFMDisplay *display,
+                                                     GLFMSurfaceDestroyedFunc surfaceDestroyedFunc) {
+    GLFMSurfaceDestroyedFunc previous = NULL;
     if (display) {
+        previous = display->surfaceDestroyedFunc;
         display->surfaceDestroyedFunc = surfaceDestroyedFunc;
     }
+    return previous;
 }
 
-void glfmSetKeyboardVisibilityChangedFunc(GLFMDisplay *display,
-                                          GLFMKeyboardVisibilityChangedFunc func) {
+GLFMKeyboardVisibilityChangedFunc glfmSetKeyboardVisibilityChangedFunc(GLFMDisplay *display,
+                                                                       GLFMKeyboardVisibilityChangedFunc func) {
+    GLFMKeyboardVisibilityChangedFunc previous = NULL;
     if (display) {
+        previous = display->keyboardVisibilityChangedFunc;
         display->keyboardVisibilityChangedFunc = func;
     }
+    return previous;
 }
 
-void glfmSetTouchFunc(GLFMDisplay *display, GLFMTouchFunc touchFunc) {
+GLFMTouchFunc glfmSetTouchFunc(GLFMDisplay *display, GLFMTouchFunc touchFunc) {
+    GLFMTouchFunc previous = NULL;
     if (display) {
+        previous = display->touchFunc;
         display->touchFunc = touchFunc;
     }
+    return previous;
 }
 
-void glfmSetKeyFunc(GLFMDisplay *display, GLFMKeyFunc keyFunc) {
+GLFMKeyFunc glfmSetKeyFunc(GLFMDisplay *display, GLFMKeyFunc keyFunc) {
+    GLFMKeyFunc previous = NULL;
     if (display) {
+        previous = display->keyFunc;
         display->keyFunc = keyFunc;
     }
+    return previous;
 }
 
-void glfmSetCharFunc(GLFMDisplay *display, GLFMCharFunc charFunc) {
+GLFMCharFunc glfmSetCharFunc(GLFMDisplay *display, GLFMCharFunc charFunc) {
+    GLFMCharFunc previous = NULL;
     if (display) {
+        previous = display->charFunc;
         display->charFunc = charFunc;
     }
+    return previous;
 }
 
-void glfmSetMemoryWarningFunc(GLFMDisplay *display, GLFMMemoryWarningFunc lowMemoryFunc) {
+GLFMMemoryWarningFunc glfmSetMemoryWarningFunc(GLFMDisplay *display, GLFMMemoryWarningFunc lowMemoryFunc) {
+    GLFMMemoryWarningFunc previous = NULL;
     if (display) {
+        previous = display->lowMemoryFunc;
         display->lowMemoryFunc = lowMemoryFunc;
     }
+    return previous;
 }
 
-void glfmSetAppFocusFunc(GLFMDisplay *display, GLFMAppFocusFunc focusFunc) {
+GLFMAppFocusFunc glfmSetAppFocusFunc(GLFMDisplay *display, GLFMAppFocusFunc focusFunc) {
+    GLFMAppFocusFunc previous = NULL;
     if (display) {
+        previous = display->focusFunc;
         display->focusFunc = focusFunc;
     }
+    return previous;
 }
 
 // MARK: Helper functions


### PR DESCRIPTION
Allow to chain callback functions by returning the previously set input functions. This also makes the api more consistent with the glfw input callback [apis](https://www.glfw.org/docs/latest/group__input.html)