### PR TITLE
Add an option to preserve the color buffer when swapping buffers

### DIFF
--- a/include/glfm.h
+++ b/include/glfm.h
@@ -126,6 +126,12 @@ typedef enum {
     GLFMMultisample4X,
 } GLFMMultisample;
 
+typedef enum {
+    GLFMSwapBehaviorPlatformDefault,
+    GLFMSwapBehaviorBufferDestroyed,
+    GLFMSwapBehaviorBufferPreserved,
+} GLFMSwapBehavior;
+
 /// GLFMUserInterfaceChrome defines whether system UI chrome (status bar, navigation bar) is shown.
 /// This value is ignored on Emscripten.
 /// GLFMUserInterfaceChromeNavigation (default)
@@ -353,6 +359,14 @@ void glfmSetKeyboardVisible(GLFMDisplay *display, bool visible);
 
 /// Returns true if the virtual keyboard is currently visible.
 bool glfmIsKeyboardVisible(GLFMDisplay *display);
+
+/// Sets the swap behavior for newly created surfaces. Currently only supported on
+/// Android. In order to take effect, the behavior should be set before the surface
+/// is created, preferable at the very beginning of the glfmMain function.
+void glfmSetSwapBehavior(GLFMDisplay *display, GLFMSwapBehavior behavior);
+
+/// Returns the swap buffer behavior.
+GLFMSwapBehavior glfmGetSwapBehavior(GLFMDisplay *display);
 
 /// Sets the function to call when the virtual keyboard changes visibility or changes bounds.
 GLFMKeyboardVisibilityChangedFunc

--- a/src/glfm_platform.h
+++ b/src/glfm_platform.h
@@ -40,6 +40,7 @@ struct GLFMDisplay {
     GLFMMultisample multisample;
     GLFMUserInterfaceOrientation allowedOrientations;
     GLFMUserInterfaceChrome uiChrome;
+    GLFMSwapBehavior swapBehavior;
 
     // Callbacks
     GLFMMainLoopFunc mainLoopFunc;
@@ -205,6 +206,20 @@ GLFMAppFocusFunc glfmSetAppFocusFunc(GLFMDisplay *display, GLFMAppFocusFunc focu
         display->focusFunc = focusFunc;
     }
     return previous;
+}
+
+void glfmSetSwapBehavior(GLFMDisplay *display, GLFMSwapBehavior behavior) {
+    if (display) {
+        display->swapBehavior = behavior;
+    }
+}
+
+GLFMSwapBehavior glfmGetSwapBehavior(GLFMDisplay *display) {
+    if (display) {
+        return display->swapBehavior;
+    }
+
+    return GLFMSwapBehaviorPlatformDefault;
 }
 
 // MARK: Helper functions

--- a/src/glfm_platform_android.c
+++ b/src/glfm_platform_android.c
@@ -543,6 +543,17 @@ static void _glfmEGLSurfaceInit(GLFMPlatformData *platformData) {
         platformData->eglSurface = eglCreateWindowSurface(platformData->eglDisplay,
                                                           platformData->eglConfig,
                                                           platformData->app->window, NULL);
+
+        switch (platformData->display->swapBehavior) {
+        case GLFMSwapBehaviorPlatformDefault:
+            // Platform default, do nothing.
+            break;
+        case GLFMSwapBehaviorBufferPreserved:
+            eglSurfaceAttrib(platformData->eglDisplay, platformData->eglSurface, EGL_SWAP_BEHAVIOR, EGL_BUFFER_PRESERVED);
+            break;
+        case GLFMSwapBehaviorBufferDestroyed:
+            eglSurfaceAttrib(platformData->eglDisplay, platformData->eglSurface, EGL_SWAP_BEHAVIOR, EGL_BUFFER_DESTROYED);
+        }
     }
 }
 
@@ -1218,6 +1229,7 @@ void android_main(struct android_app *app) {
         // This should call glfmInit()
         platformData->display = calloc(1, sizeof(GLFMDisplay));
         platformData->display->platformData = platformData;
+        platformData->display->swapBehavior = GLFMSwapBehaviorPlatformDefault;
         glfmMain(platformData->display);
     }
 


### PR DESCRIPTION
This is useful for partial updates of the frame and to avoid flickering if the application intentionally skips frames (like rending at 30 FPS) to save battery.

See:
https://www.khronos.org/registry/EGL/sdk/docs/man/html/eglSurfaceAttrib.xhtml