### PR TITLE
docs: fix simple typo, recieves -> receives

### DIFF
--- a/include/glfm.h
+++ b/include/glfm.h
@@ -293,7 +293,7 @@ typedef void (*GLFMSurfaceRefreshFunc)(GLFMDisplay *display);
 /// Callback function when the OpenGL surface is destroyed.
 typedef void (*GLFMSurfaceDestroyedFunc)(GLFMDisplay *display);
 
-/// Callback function when the system recieves a low memory warning.
+/// Callback function when the system receives a low memory warning.
 typedef void (*GLFMMemoryWarningFunc)(GLFMDisplay *display);
 
 typedef void (*GLFMAppFocusFunc)(GLFMDisplay *display, bool focused);


### PR DESCRIPTION
There is a small typo in include/glfm.h.

Should read `receives` rather than `recieves`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md